### PR TITLE
Fix WDT

### DIFF
--- a/src/imports/watchdog/systemdwatchdog.cpp
+++ b/src/imports/watchdog/systemdwatchdog.cpp
@@ -4,17 +4,36 @@
 #include <systemd/sd-daemon.h>
 #endif
 
+class SystemdWatchDog::Private
+{
+public:
+    bool enabled = false;
+};
+
 SystemdWatchDog::SystemdWatchDog(QObject *parent)
     : QObject(parent)
+    , d(new Private)
 {
 #if !QT_CONFIG(systemd_watchdog)
-    qWarning("SystemdWatchDog is disabled");
+    qWarning("SystemdWatchDog is not supported");
+#else
+    // WATCHDOG_USEC is set by systemd when WatchdogSec is set in its service-unit
+    if (qEnvironmentVariableIsSet("WATCHDOG_USEC")) {
+        qInfo("SystemdWatchDog is available");
+        d->enabled = true;
+    } else {
+        qInfo("SystemdWatchDog is not available");
+    }
 #endif
 }
+
+SystemdWatchDog::~SystemdWatchDog() = default;
 
 void SystemdWatchDog::pang()
 {
 #if QT_CONFIG(systemd_watchdog)
-    sd_notify(0, "WATCHDOG=1");
+    if (d->enabled) {
+        sd_notify(0, "WATCHDOG=1");
+    }
 #endif
 }

--- a/src/imports/watchdog/systemdwatchdog.h
+++ b/src/imports/watchdog/systemdwatchdog.h
@@ -11,9 +11,14 @@ class SystemdWatchDog : public QObject
     Q_DISABLE_COPY(SystemdWatchDog)
 public:
     explicit SystemdWatchDog(QObject *parent = nullptr);
+    ~SystemdWatchDog() override;
 
 public slots:
     void pang();
+
+private:
+    class Private;
+    QScopedPointer<Private> d;
 };
 
 #endif // SYSTEMDWATCHDOG_H

--- a/src/multiprocesssystem/qmpswatchdogmanager.cpp
+++ b/src/multiprocesssystem/qmpswatchdogmanager.cpp
@@ -1,8 +1,10 @@
 #include "qmpswatchdogmanager.h"
+#include "qmpsapplicationmanager.h"
 
 class QMpsWatchDogManager::Private
 {
 public:
+    QMpsApplicationManager applicationManager;
     static QMpsWatchDogManager *server;
 };
 
@@ -15,6 +17,14 @@ QMpsWatchDogManager::QMpsWatchDogManager(QObject *parent, Type type)
     switch (type) {
     case Server:
         Private::server = this;
+        d->applicationManager.init();
+        connect (&d->applicationManager, &QMpsApplicationManager::applicationStatusChanged,
+                 this, [this](const QMpsApplication &application, const QString &status) {
+            if (status == QStringLiteral("destroyed")) {
+                qDebug() << "WatchDogManager ejects" << application.key();
+                this->finished(application);
+            }
+        });
         break;
     case Client:
         break;


### PR DESCRIPTION
・Systemd WDT が有効なときだけ systemdWatchDog が WATCHDOG=1 を投げるようにする
・Application が destroyed ステータスになったときに WatchDogManager から該当アプリケーションを消す