### PR TITLE
Support arguments for apps

### DIFF
--- a/src/multiprocesssystem/qmpsapplication.cpp
+++ b/src/multiprocesssystem/qmpsapplication.cpp
@@ -18,6 +18,7 @@ public:
     QJsonObject uriHandlers;
     Attributes attributes = None;
     QString status = QStringLiteral("none");
+    QString arguments = QStringLiteral("");
 };
 
 QMpsApplication::QMpsApplication() : d(new Private)
@@ -147,6 +148,17 @@ void QMpsApplication::setStatus(const QString &status)
 {
     if (this->status() == status) return;
     d->status = status;
+}
+
+QString QMpsApplication::arguments() const
+{
+    return d->arguments;
+}
+
+void QMpsApplication::setArguments(const QString &arguments)
+{
+    if (d->arguments == arguments) return;
+    d->arguments = arguments;
 }
 
 bool QMpsApplication::isValid() const

--- a/src/multiprocesssystem/qmpsapplication.h
+++ b/src/multiprocesssystem/qmpsapplication.h
@@ -23,6 +23,7 @@ class MULTIPROCESSSYSTEM_EXPORT QMpsApplication
     Q_PROPERTY(QJsonObject uri_handlers READ uriHandlers WRITE setUriHandlers)
     Q_PROPERTY(Attributes attributes READ attributes WRITE setAttributes)
     Q_PROPERTY(QString status READ status WRITE setStatus)
+    Q_PROPERTY(QString arguments READ arguments WRITE setArguments)
 public:
     enum Attribute {
         None = 0x00,
@@ -71,6 +72,9 @@ public:
 
     QString status() const;
     void setStatus(const QString &status);
+
+    QString arguments() const;
+    void setArguments(const QString &arguments);
 
     bool isValid() const;
 

--- a/src/multiprocesssystem/qmpsapplicationmanager.cpp
+++ b/src/multiprocesssystem/qmpsapplicationmanager.cpp
@@ -70,6 +70,15 @@ QMpsApplication QMpsApplicationManager::current() const
     return QMpsIpcInterfaceGetter(QMpsApplication, QMpsApplication(), current);
 }
 
+void QMpsApplicationManager::setApplicationArguments(const QMpsApplication &application, const QStringList &arguments)
+{
+    if (!d->applications.contains(application)) return;
+    int index = d->applications.indexOf(application);
+    QMpsApplication &app = d->applications[index];
+    app.setArguments(arguments.join(' '));
+    qDebug() << "Arguments" << app.key() << arguments;
+}
+
 void QMpsApplicationManager::setCurrent(const QMpsApplication &current)
 {
     qDebug() << current.key();

--- a/src/multiprocesssystem/qmpsapplicationmanager.h
+++ b/src/multiprocesssystem/qmpsapplicationmanager.h
@@ -17,6 +17,7 @@ public:
 
     QList<QMpsApplication> applications() const;
     QMpsApplication current() const;
+    void setApplicationArguments(const QMpsApplication &application, const QStringList &arguments);
 
     Q_INVOKABLE QMpsApplication findByKey(const QString &key) const;
     Q_INVOKABLE QString applicationStatus(const QMpsApplication &application) const;

--- a/src/plugins/multiprocesssystem/applicationmanager/systemd/systemdapplicationmanager.cpp
+++ b/src/plugins/multiprocesssystem/applicationmanager/systemd/systemdapplicationmanager.cpp
@@ -75,6 +75,7 @@ SystemdApplicationManager::SystemdApplicationManager(QObject *parent, Type type)
                 qDebug() << mo->method(i).name();
 #endif
             qDebug() << unit->property("LoadState") << unit->property("ActiveState") << unit->property("SubState");
+            setApplicationArguments(application, arguments);
             emit activated(application, arguments);
         }
     });


### PR DESCRIPTION
アプリ起動時にコマンドライン引数を参照できるようにした。
特にURIハンドラ経由の起動時で引数にURIが渡されているのに参照する方法がないため。
ひとまず systemd のみ対応。